### PR TITLE
Update landing page to adopt shipley design pattern

### DIFF
--- a/app/views/landing.scala.html
+++ b/app/views/landing.scala.html
@@ -24,27 +24,32 @@
     @main_template(title = messages("common.importDeclarations"), bodyClasses = None, mainClass = Some("full-width")) {
         <div class="form-group">
             <h1 class="heading-xlarge">@messages("common.importDeclarations")</h1>
-            <p><a class="button button-start" href="@routes.DeclarationController.displaySubmitForm("declarant-details")">@messages("common.button.createNew")</a></p>
         </div>
-        <h2 class="heading-medium">@messages("landingpage.submissions.heading")</h2>
         @if(submissions.nonEmpty) {
-        <table>
-            <thead>
-                <th scope="col">@messages("landingpage.LRN")</th>
-                <th scope="col">@messages("landingpage.MRN")</th>
-                <th scope="col">@messages("landingpage.dateSubmitted")</th>
-            </thead>
-            <tbody>
-            @for(submission <- submissions) {
-                <tr>
-                    <td scope="row">@submission.lrn.getOrElse(messages("lrn.missing"))</td>
-                    <td>@submission.mrn.getOrElse(messages("landingpage.MRN.unknown"))</td>
-                    <td>@formatDate(new LocalDate(submission.submittedTimestamp))</td>
-                </tr>
-            }
-            </tbody>
-        </table>
+            <p><a class="button" href="@routes.DeclarationController.displaySubmitForm("declarant-details")">@messages("common.button.createNew")</a></p>
+
+            <h2 class="heading-medium">@messages("landingpage.submissions.heading")</h2>
+
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">@messages("landingpage.LRN")</th>
+                        <th scope="col">@messages("landingpage.MRN")</th>
+                        <th scope="col">@messages("landingpage.dateSubmitted")</th>
+                    </tr>
+                </thead>
+                <tbody>
+                @for(submission <- submissions) {
+                    <tr>
+                        <td scope="row">@submission.lrn.getOrElse(messages("lrn.missing"))</td>
+                        <td>@submission.mrn.getOrElse(messages("landingpage.MRN.unknown"))</td>
+                        <td>@formatDate(new LocalDate(submission.submittedTimestamp))</td>
+                    </tr>
+                }
+                </tbody>
+            </table>
         } else {
-        <p>@messages("landingpage.submissions.empty")</p>
+            <p>@messages("landingpage.submissions.empty")</p>
+            <p><a class="button" href="@routes.DeclarationController.displaySubmitForm("declarant-details")">@messages("common.button.createNew")</a></p>
         }
     }


### PR DESCRIPTION
Shipley design pattern for landing pages:
- Heading
- if first time and no previous data from using the service - show sentence tellin guser there is no data followed by 'start service' button
- if there is data from previous submissions - show starft button under the heading and display data from previous submission below 'start button'

## Screenshots
### Before
<img width="989" alt="screenshot 2019-01-28 at 09 23 52" src="https://user-images.githubusercontent.com/1692222/51826883-07c6d280-22e0-11e9-82d6-2f6c554bcc72.png">

### After
<img width="978" alt="screenshot 2019-01-28 at 07 48 55" src="https://user-images.githubusercontent.com/1692222/51826907-14e3c180-22e0-11e9-9504-801225151248.png">
